### PR TITLE
Fix CMake file generation on Windows

### DIFF
--- a/cmake.py
+++ b/cmake.py
@@ -153,7 +153,7 @@ class CMakeFileGenerator:
             for x in f.close():
                 # build/gen/blah -> gen/blah
                 x = x[0].replace('\\', '/')
-                x = x.split(os.sep, 1)[-1]
+                x = x.split('/', 1)[-1]
                 self.__files.append(x)
 
     def __worker(self):


### PR DESCRIPTION
Because `os.sep` is `'\\'` on Windows, This fixes CMake generation on the platform by using the fixed `'/'` string instead.