### PR TITLE
Module: Correct BUILD_CONST_KEY_MAP opcode generation.  Fixes #5.

### DIFF
--- a/module.py
+++ b/module.py
@@ -551,6 +551,8 @@ class Module(ModuleBase):
             context.end_block()
 
         elif op == BUILD_CONST_KEY_MAP:
+            context.add_decl_once('i', 'int', None, False)
+
             context.begin_block()
 
             context.insert_line('x = POP(); /* keys */')
@@ -562,16 +564,25 @@ class Module(ModuleBase):
             context.insert_handle_error(line, label)
             context.end_block()
 
-            for i in range(oparg):
-                context.insert_line('v = PyTuple_GET_ITEM(x, %d);' % (oparg - i - 1))
-                context.insert_line('w = POP();')
-                context.insert_line('err = PyDict_SetItem(u, v, w);')
-                context.insert_line('Py_DECREF(w);')
-                context.insert_line('if (err != 0)')
-                context.begin_block()
-                context.insert_line('Py_DECREF(u);')
-                context.insert_handle_error(line, label)
-                context.end_block()
+            context.insert_line('for (i = %d; i > 0; i--)' % oparg)
+            context.begin_block()
+            context.insert_line('v = PyTuple_GET_ITEM(x, %d - i);' % oparg)
+            context.insert_line('w = PEEK(0 + i);')
+            context.insert_line('err = PyDict_SetItem(u, v, w);')
+            context.insert_line('if (err != 0)')
+
+            context.begin_block()
+            context.insert_line('Py_DECREF(u);')
+            context.insert_handle_error(line, label)
+            context.end_block()
+
+            context.end_block()
+
+            context.insert_line('for (i = %d; i > 0; i--)' % oparg)
+            context.begin_block()
+            context.insert_line('x = POP();')
+            context.insert_line('Py_DECREF(x);')
+            context.end_block()
 
             context.insert_line('PUSH(u);')
 

--- a/module.py
+++ b/module.py
@@ -551,8 +551,6 @@ class Module(ModuleBase):
             context.end_block()
 
         elif op == BUILD_CONST_KEY_MAP:
-            context.add_decl_once('i', 'int', None, False)
-
             context.begin_block()
 
             context.insert_line('x = POP(); /* keys */')
@@ -564,25 +562,22 @@ class Module(ModuleBase):
             context.insert_handle_error(line, label)
             context.end_block()
 
-            context.insert_line('for (i = %d; i > 0; i--)' % oparg)
-            context.begin_block()
-            context.insert_line('v = PyTuple_GET_ITEM(x, %d - i);' % oparg)
-            context.insert_line('w = PEEK(0 + i);')
-            context.insert_line('err = PyDict_SetItem(u, v, w);')
-            context.insert_line('if (err != 0)')
+            for i in range(oparg):
+                context.insert_line('v = PyTuple_GET_ITEM(x, %d);' % i)
+                context.insert_line('w = PEEK(%d);' % (oparg - i))
+                context.insert_line('err = PyDict_SetItem(u, v, w);')
 
-            context.begin_block()
-            context.insert_line('Py_DECREF(u);')
-            context.insert_handle_error(line, label)
-            context.end_block()
+                context.insert_line('if (err != 0)')
+                context.begin_block()
+                context.insert_line('Py_DECREF(u);')
+                context.insert_handle_error(line, label)
+                context.end_block()
 
-            context.end_block()
+            context.insert_line('Py_DECREF(x); /* keys */')
 
-            context.insert_line('for (i = %d; i > 0; i--)' % oparg)
-            context.begin_block()
-            context.insert_line('x = POP();')
-            context.insert_line('Py_DECREF(x);')
-            context.end_block()
+            for i in range(oparg):
+                context.insert_line('x = POP();')
+                context.insert_line('Py_DECREF(x);')
 
             context.insert_line('PUSH(u);')
 


### PR DESCRIPTION
The old code generated for the `BUILD_CONST_KEY_MAP` opcode would get the keys in the tuple pushed to the stack in reverse order, and it would also pop the values within the stack, resulting in reversed values (which is correct for the reversed keys).  This is slightly more explained in issue #5.

This PR fixes the issue by getting the keys in the tuple in the correct left to right (0 to `oparg - 1`) order, and `PEEK()`ing at the stack instead of outright popping them (though they are popped and decreases the reference at the end), matching the behavior of CPython's [`ceval`](https://github.com/python/cpython/blob/3.6/Python/ceval.c#L2744) implementation.

To make things easier, here's the comparison of the old and new generated code (alongside with the bytecode disassembly) of initializing the following dictionary: `{'Hello': 1, 'World!': 2}` (Taken from the sample attached in the previously mentioned issue).

Comments and suggestions are welcome.

EDIT: Updated the new code to match the newly committed code which removes the for loop.

Disassembly:
```
0 LOAD_CONST               0 (1)
2 LOAD_CONST               1 (2)
4 LOAD_CONST               2 (('Hello', 'World!'))
6 BUILD_CONST_KEY_MAP      2
```

Old generated code:
```c
  label_0:
  {
    x = __consts_main[0]; /* 1 */
    Py_INCREF(x);
    PUSH(x);
  }
  label_2:
  {
    x = __consts_main[1]; /* 2 */
    Py_INCREF(x);
    PUSH(x);
  }
  label_4:
  {
    x = __consts_main[2]; /* ('Hello', 'World!') */
    Py_INCREF(x);
    PUSH(x);
  }
  label_6:
  {
    x = POP(); /* keys */
    u = _PyDict_NewPresized(2);
    if (u == NULL)
    {
      Py_DECREF(x);
      f->f_lineno = 5;
      goto error;
    }
    v = PyTuple_GET_ITEM(x, 1);
    w = POP();
    err = PyDict_SetItem(u, v, w);
    Py_DECREF(w);
    if (err != 0)
    {
      Py_DECREF(u);
      f->f_lineno = 5;
      goto error;
    }
    v = PyTuple_GET_ITEM(x, 0);
    w = POP();
    err = PyDict_SetItem(u, v, w);
    Py_DECREF(w);
    if (err != 0)
    {
      Py_DECREF(u);
      f->f_lineno = 5;
      goto error;
    }
    PUSH(u);
  }
```

New generated code (Updated to match commit 64f4a3b):
```c
  label_0:
  {
    x = __consts_main[0]; /* 1 */
    Py_INCREF(x);
    PUSH(x);
  }
  label_2:
  {
    x = __consts_main[1]; /* 2 */
    Py_INCREF(x);
    PUSH(x);
  }
  label_4:
  {
    x = __consts_main[2]; /* ('Hello', 'World!') */
    Py_INCREF(x);
    PUSH(x);
  }
  label_6:
  {
    x = POP(); /* keys */
    u = _PyDict_NewPresized(2);
    if (u == NULL)
    {
      Py_DECREF(x);
      f->f_lineno = 5;
      goto error;
    }
    v = PyTuple_GET_ITEM(x, 0);
    w = PEEK(2);
    err = PyDict_SetItem(u, v, w);
    if (err != 0)
    {
      Py_DECREF(u);
      f->f_lineno = 5;
      goto error;
    }
    v = PyTuple_GET_ITEM(x, 1);
    w = PEEK(1);
    err = PyDict_SetItem(u, v, w);
    if (err != 0)
    {
      Py_DECREF(u);
      f->f_lineno = 5;
      goto error;
    }
    Py_DECREF(x); /* keys */
    x = POP();
    Py_DECREF(x);
    x = POP();
    Py_DECREF(x);
    PUSH(u);
```